### PR TITLE
fix: Required OS versions decreasing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,10 +5,10 @@ import PackageDescription
 let package = Package(
   name: "AlgoliaSDK",
   platforms: [
-    .iOS(.v15),
-    .macOS(.v12),
-    .watchOS(.v2),
-    .tvOS(.v9)
+    .iOS(.v13),
+    .macOS(.v10_15),
+    .watchOS(.v6),
+    .tvOS(.v13)
   ],
   products: [
     .library(

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![swift](https://img.shields.io/badge/Swift-5.6-orange)](https://www.swift.org)
 [![test](https://github.com/VladislavFitz/algolia-swift-sdk/actions/workflows/test.yml/badge.svg)](https://github.com/VladislavFitz/algolia-swift-sdk/actions/workflows/test.yml)
+![platform](https://img.shields.io/badge/platforms-iOS_13+%20%7C%20macOS_10.15+%20%7C%20tvOS_13+%20%7C%20watchOS_6+-blue.svg?style=flat")
 [![MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 # Algolia Swift SDK

--- a/Sources/AlgoliaFoundation/Transport/URLSession+HTTPClient.swift
+++ b/Sources/AlgoliaFoundation/Transport/URLSession+HTTPClient.swift
@@ -2,6 +2,14 @@ import Foundation
 
 extension URLSession: HTTPClient {
   public func perform(_ request: URLRequest) async throws -> (Data, URLResponse) {
-    try await data(for: request)
+    try await withCheckedThrowingContinuation({ continuation in
+      dataTask(with: request) { data, response, error in
+        if let error = error {
+          continuation.resume(throwing: error)
+        } else if let data = data, let response = response {
+          continuation.resume(returning: (data, response))
+        }
+      }.resume()
+    })
   }
 }


### PR DESCRIPTION
- Alter the `HTTPClient` protocol implementation to allow decreasing the required OS versions
- Decrease the required OS versions in the package description to the necessary minimum for each platform